### PR TITLE
Bump version and download from github

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ find_package(catkin REQUIRED)
 
 include(ExternalProject)
 
-set(VERSION 2.4.1)
+set(VERSION 2.4.2)
 
 catkin_package(
     DEPENDS
@@ -21,7 +21,7 @@ set(NLOPT_INSTALL_DIR ${NLOPT_INSTALL_PREFIX}/${CMAKE_INSTALL_PREFIX})
 configure_file(make_install_nlopt.sh.in ${CMAKE_BINARY_DIR}/make_install_nlopt.sh)
 
 ExternalProject_Add(nlopt_src
-  DOWNLOAD_COMMAND wget http://ab-initio.mit.edu/nlopt/nlopt-${VERSION}.tar.gz
+  DOWNLOAD_COMMAND wget https://github.com/ethz-asl/thirdparty_library_binaries/raw/master/nlopt-${VERSION}.tar.gz
   PATCH_COMMAND tar -xzf ../nlopt-${VERSION}.tar.gz && rm -rf ../nlopt_src-build/nlopt-${VERSION} && mv nlopt-${VERSION} ../nlopt_src-build/
   CONFIGURE_COMMAND nlopt-${VERSION}/configure --with-cxx --without-matlab --with-pic --prefix=${CMAKE_INSTALL_PREFIX}
   BUILD_COMMAND make


### PR DESCRIPTION
Recently we saw some problems with the MIT server. This PR bumps the version up by one and moves the hosting. Changelog:
```
20 May 2014
Fix CRS for empty dimensions (where lower == upper bound) (issue #13).
Improvements to CMake (thanks to @xantares) and Windows builds (issue #12).
Fix guile2 compatibility (issue #21).
```

@markusachtelik @burrimi attn.